### PR TITLE
Add a Get button

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -17,3 +17,20 @@
 .streamdeck-action-svg {
   border-radius: 20px;       /* Optional: slightly rounded corners */
 }
+
+.get-button {
+  display: inline-block;
+  background-color: #1e6bff;
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 500;
+  padding: 12px 24px;
+  border-radius: 8px;
+  text-align: center;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.get-button:hover {
+  background-color: #193ed4;
+}

--- a/content/docs/streamdeck-trackaudio/_index.md
+++ b/content/docs/streamdeck-trackaudio/_index.md
@@ -4,6 +4,8 @@ description: Actions to control TrackAudio from your favorite Stream Deck device
 og_image: ogimage/streamdeck-trackaudio.png
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 > [!IMPORTANT]
 > This plugin requires [TrackAudio beta 1.3.0-beta.1](https://github.com/pierr3/TrackAudio/releases/tag/1.3.0-beta.1) or later. It will not work with earlier versions of TrackAudio.
 

--- a/content/docs/streamdeck-trackaudio/main-volume/index.md
+++ b/content/docs/streamdeck-trackaudio/main-volume/index.md
@@ -7,6 +7,8 @@ next: /docs/streamdeck-trackaudio/push-to-talk
 weight: 30
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 The main volume action displays the current volume of TrackAudio and enables changing the volume. This action requires a dial control, available on the [Stream Deck +](https://www.elgato.com/us/en/p/stream-deck-plus-black).
 
 Turning the knob will adjust the station volume.

--- a/content/docs/streamdeck-trackaudio/push-to-talk/index.md
+++ b/content/docs/streamdeck-trackaudio/push-to-talk/index.md
@@ -7,6 +7,8 @@ next: /docs/streamdeck-trackaudio/station-status
 weight: 40
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 The push to talk action triggers the transmit function in TrackAudio. You can use it to:
 
 - Start transmission using a Stream Deck key

--- a/content/docs/streamdeck-trackaudio/station-status/index.md
+++ b/content/docs/streamdeck-trackaudio/station-status/index.md
@@ -7,6 +7,8 @@ next: /docs/streamdeck-trackaudio/station-volume
 weight: 50
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 The station status action displays the current status of a single station's button in TrackAudio. You can use it to:
 
 - Toggle TX, RX, or XCA state of a station.

--- a/content/docs/streamdeck-trackaudio/station-volume/index.md
+++ b/content/docs/streamdeck-trackaudio/station-volume/index.md
@@ -7,6 +7,8 @@ next: /docs/streamdeck-trackaudio/trackaudio-status
 weight: 60
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 ## Configuring a station volume action
 
 The station volume action displays the current volume of a specific station and enables changing the volume, as well as muting

--- a/content/docs/streamdeck-trackaudio/trackaudio-status/index.md
+++ b/content/docs/streamdeck-trackaudio/trackaudio-status/index.md
@@ -7,6 +7,8 @@ next: /docs/streamdeck-trackaudio/examples
 weight: 70
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea" title="Get from marketplace" >}}
+
 The TrackAudio status action shows the status of the connection between Stream Deck and TrackAudio, and whether the voice connection in TrackAudio is up. A long press of the action will force a refresh of all the Stream Deck TrackAudio actions.
 
 ### TrackAudio status action settings <!-- omit from toc -->

--- a/content/docs/streamdeck-vatis/_index.md
+++ b/content/docs/streamdeck-vatis/_index.md
@@ -5,13 +5,14 @@ next: /docs/streamdeck-vatis/atis-letter
 og_image: ogimage/streamdeck-vatis.png
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/vatis-878fcd1a-7e0a-4d6e-bd36-c70b075573ea" title="Get from marketplace" >}}
+
 > [!IMPORTANT]
 > This plugin requires [vATIS v4.1.0-beta.4](https://vatis.app/) or later.
 
 ![Example profile showing ATIS letter actions for KHIO, KPDX, and KUAO. KPDX has an orange background indicating a new ATIS letter. All three show the station name above the letter and the current altimeter below the letter.](example.png)
 
 This Stream Deck plugin provides actions to interact with [vATIS](https://vatis.app/) running on your local machine.
-[Download the plugin from the releases page](https://github.com/neilenns/streamdeck-vatis/releases/latest).
 
 ## Actions
 

--- a/content/docs/streamdeck-vatis/atis-letter/index.md
+++ b/content/docs/streamdeck-vatis/atis-letter/index.md
@@ -5,6 +5,8 @@ next: vatis-status
 og_image: streamdeck-vatis.png
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/vatis-878fcd1a-7e0a-4d6e-bd36-c70b075573ea" title="Get from marketplace" >}}
+
 The ATIS letter action shows the current ATIS information for the specified station. You can use it to:
 
 - See the current ATIS letter for a station

--- a/content/docs/streamdeck-vatis/vatis-status/index.md
+++ b/content/docs/streamdeck-vatis/vatis-status/index.md
@@ -5,6 +5,8 @@ prev: /docs/streamdeck-vatis/atis-letter
 og_image: streamdeck-vatis.png
 ---
 
+{{< get-button url="https://marketplace.elgato.com/product/vatis-878fcd1a-7e0a-4d6e-bd36-c70b075573ea" title="Get from marketplace" >}}
+
 The vATIS status action shows the state of the connection to the vATIS application. You can use it to:
 
 - Verify your Stream Deck is connected to vATIS

--- a/layouts/shortcodes/get-button.html
+++ b/layouts/shortcodes/get-button.html
@@ -1,0 +1,3 @@
+<a href="{{ .Get "url" }}" class="get-button" target="_blank" rel="noopener noreferrer">
+  {{ .Get "title" }}
+</a>


### PR DESCRIPTION
Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new "Get from marketplace" button to documentation pages for TrackAudio and vATIS Stream Deck plugins
	- Introduced a custom CSS class for styling marketplace buttons

- **Documentation**
	- Updated documentation to include direct links to plugin marketplace pages
	- Removed direct download links in favor of marketplace buttons

- **Style**
	- Added new CSS styling for marketplace buttons with hover effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->