### PR TITLE
Remove duplicate link in TrackAudio action docs

### DIFF
--- a/content/docs/streamdeck-trackaudio/_index.md
+++ b/content/docs/streamdeck-trackaudio/_index.md
@@ -9,7 +9,7 @@ og_image: ogimage/streamdeck-trackaudio.png
 > [!IMPORTANT]
 > This plugin requires [TrackAudio beta 1.3.0-beta.1](https://github.com/pierr3/TrackAudio/releases/tag/1.3.0-beta.1) or later. It will not work with earlier versions of TrackAudio.
 
-This Stream Deck plugin provides actions to interact with TrackAudio. [Get the plugin from the Elgato marketplace](https://marketplace.elgato.com/product/trackaudio-e913a0ca-4c12-411d-a5a6-acf5f6c4bdea). Need inspiration for how to use these actions? Check out the [examples](examples/).
+This Stream Deck plugin provides actions to interact with TrackAudio. Need inspiration for how to use these actions? Check out the [examples](examples/).
 
 ![Screenshot a Stream Deck profile with buttons for stations, current ATIS letter, a hotline, and a push-to-talk button](example.png)
 


### PR DESCRIPTION
Fixes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Stream Deck TrackAudio plugin documentation
	- Removed direct marketplace link from documentation
	- Maintained existing documentation structure and content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->